### PR TITLE
kvi: recursive prefix-stripping model + cold-bench (~2.4x on commitment)

### DIFF
--- a/scratch/kvi_coldbench/main.go
+++ b/scratch/kvi_coldbench/main.go
@@ -1,0 +1,449 @@
+// Cold/warm full-Get benchmark for the learned MMPHF+EF .kvi.
+//
+// Cold full-Get (key+value) over N random keys with `vmtouch -e` eviction,
+// comparing baseline recsplit .kvi against the new MMPHF+EF index. The
+// value-read code is identical for both paths, so the latency difference is
+// purely index-faulting cost.
+//
+// The whole index is written to disk (residual.kvi + offsets.ef + model).
+// recsplit residual + EF are evicted/faulted like the baseline .kvi; the model
+// is pinned resident, mirroring how .bt keeps its pivot array resident.
+//
+// Lean build: keys live in a single arena ([]byte + offsets), x is recomputed
+// on the fly, so it scales to the big bloatnet files without an N-sized u128 array.
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/mmap"
+	"github.com/erigontech/erigon/db/recsplit"
+	"github.com/erigontech/erigon/db/recsplit/eliasfano32"
+	"github.com/erigontech/erigon/db/seg"
+)
+
+const K = 8
+
+type u128 [K]uint64
+
+const limbBase = 1.8446744073709552e19
+
+func keyToX(k []byte) u128 {
+	var x u128
+	for i := 0; i < K*8; i++ {
+		limb := i / 8
+		x[limb] <<= 8
+		if i < len(k) {
+			x[limb] |= uint64(k[i])
+		}
+	}
+	return x
+}
+func less(a, b u128) bool {
+	for i := 0; i < K; i++ {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false
+}
+func leq(a, b u128) bool { return !less(b, a) }
+func fdelta(a, b u128) float64 {
+	var d float64
+	for i := 0; i < K; i++ {
+		d = d*limbBase + (float64(a[i]) - float64(b[i]))
+	}
+	return d
+}
+
+type segment struct {
+	x0    u128
+	y0    float64
+	slope float64
+}
+
+// key arena
+type arena struct {
+	data []byte
+	off  []uint64 // len n+1
+}
+
+func (a *arena) n() int          { return len(a.off) - 1 }
+func (a *arena) key(i int) []byte { return a.data[a.off[i]:a.off[i+1]] }
+func (a *arena) x(i int) u128     { return keyToX(a.key(i)) }
+
+func buildSegments(a *arena, eps float64) []segment {
+	var segs []segment
+	n := a.n()
+	i := 0
+	for i < n {
+		x0 := a.x(i)
+		y0 := float64(i)
+		slopeLo, slopeHi := math.Inf(-1), math.Inf(1)
+		j := i + 1
+		for ; j < n; j++ {
+			dx := fdelta(a.x(j), x0)
+			yj := float64(j)
+			if dx == 0 {
+				if math.Abs(yj-y0) > eps {
+					break
+				}
+				continue
+			}
+			lo := (yj - eps - y0) / dx
+			hi := (yj + eps - y0) / dx
+			if lo > slopeLo {
+				slopeLo = lo
+			}
+			if hi < slopeHi {
+				slopeHi = hi
+			}
+			if slopeLo > slopeHi {
+				break
+			}
+		}
+		slope := 0.0
+		if !math.IsInf(slopeLo, 0) && !math.IsInf(slopeHi, 0) {
+			slope = (slopeLo + slopeHi) / 2
+		} else if !math.IsInf(slopeLo, 0) {
+			slope = slopeLo
+		} else if !math.IsInf(slopeHi, 0) {
+			slope = slopeHi
+		}
+		segs = append(segs, segment{x0: x0, y0: y0, slope: slope})
+		i = j
+	}
+	return segs
+}
+
+func predict(segs []segment, x u128, n int) int {
+	lo, hi, idx := 0, len(segs)-1, 0
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		if leq(segs[mid].x0, x) {
+			idx = mid
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	s := segs[idx]
+	p := int(math.Round(s.y0 + s.slope*fdelta(x, s.x0)))
+	if p < 0 {
+		p = 0
+	}
+	if p >= n {
+		p = n - 1
+	}
+	return p
+}
+
+const segBytes = K*8 + 16 // x0 + y0 + slope
+
+func writeModel(path string, segs []segment) int64 {
+	buf := make([]byte, len(segs)*segBytes)
+	for s, seg := range segs {
+		o := s * segBytes
+		for l := 0; l < K; l++ {
+			binary.BigEndian.PutUint64(buf[o+l*8:], seg.x0[l])
+		}
+		binary.BigEndian.PutUint64(buf[o+K*8:], math.Float64bits(seg.y0))
+		binary.BigEndian.PutUint64(buf[o+K*8+8:], math.Float64bits(seg.slope))
+	}
+	must(os.WriteFile(path, buf, 0o644))
+	return int64(len(buf))
+}
+
+func readModel(path string) []segment {
+	buf, err := os.ReadFile(path)
+	must(err)
+	segs := make([]segment, len(buf)/segBytes)
+	for s := range segs {
+		o := s * segBytes
+		for l := 0; l < K; l++ {
+			segs[s].x0[l] = binary.BigEndian.Uint64(buf[o+l*8:])
+		}
+		segs[s].y0 = math.Float64frombits(binary.BigEndian.Uint64(buf[o+K*8:]))
+		segs[s].slope = math.Float64frombits(binary.BigEndian.Uint64(buf[o+K*8+8:]))
+	}
+	return segs
+}
+
+func main() {
+	kvPath := flag.String("kv", "", ".kv data file")
+	eps := flag.Int("eps", 31, "model error bound")
+	out := flag.String("out", "", "artifact dir (default: tmp)")
+	nkeys := flag.Int("nkeys", 15000, "random keys to time")
+	flag.Parse()
+	if *kvPath == "" {
+		fmt.Println("need -kv")
+		os.Exit(1)
+	}
+	logger := log.New()
+	ctx := context.Background()
+	if *out == "" {
+		*out, _ = os.MkdirTemp("", "coldbench")
+	}
+	os.MkdirAll(*out, 0o755)
+	base := filepath.Base(*kvPath)
+	fmt.Printf("=== %s  eps=%d  nkeys=%d ===\n", base, *eps, *nkeys)
+
+	// --- extract into arena ---
+	d, err := seg.NewDecompressor(*kvPath)
+	must(err)
+	g := d.MakeGetter()
+	g.Reset(0)
+	cnt := d.Count() / 2
+	ar := &arena{data: make([]byte, 0, 1<<30), off: make([]uint64, 0, cnt+1)}
+	offs := make([]uint64, 0, cnt)
+	buf := make([]byte, 0, 256)
+	for g.HasNext() {
+		key, valPos := g.Next(buf[:0])
+		ar.off = append(ar.off, uint64(len(ar.data)))
+		ar.data = append(ar.data, key...)
+		offs = append(offs, valPos)
+		if g.HasNext() {
+			g.Skip()
+		}
+	}
+	ar.off = append(ar.off, uint64(len(ar.data)))
+	n := ar.n()
+	maxOffset := offs[n-1]
+	d.Close() // drop the map so vmtouch can evict .kv
+	fmt.Printf("keys=%d  .kv=%.2f GB  keyArena=%.1f GB\n", n, float64(fileSize(*kvPath))/1e9, float64(len(ar.data))/1e9)
+
+	// --- model ---
+	segs := buildSegments(ar, float64(*eps))
+	minE, maxE := math.MaxInt, math.MinInt
+	residuals := make([]uint32, n)
+	for i := 0; i < n; i++ {
+		e := i - predict(segs, ar.x(i), n)
+		residuals[i] = uint32(e) // bias applied after minE known
+		if e < minE {
+			minE = e
+		}
+		if e > maxE {
+			maxE = e
+		}
+	}
+	for i := 0; i < n; i++ {
+		residuals[i] = uint32(int(int32(residuals[i])) - minE)
+	}
+	residBits := int(math.Ceil(math.Log2(float64(maxE - minE + 1))))
+	fmt.Printf("model: segs=%d  resid range=[%d,%d] (%d bits/key)\n", len(segs), minE, maxE, residBits)
+
+	// --- artifacts on disk ---
+	residPath := filepath.Join(*out, base+".mmphf.kvi")
+	efPath := filepath.Join(*out, base+".mmphf.ef")
+	modelPath := filepath.Join(*out, base+".mmphf.model")
+	var salt uint32 = 0
+	rs, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
+		KeyCount: n, Enums: false, BucketSize: recsplit.DefaultBucketSize,
+		LeafSize: recsplit.DefaultLeafSize, TmpDir: *out, IndexFile: residPath,
+		Salt: &salt, NoFsync: true,
+	}, logger)
+	must(err)
+	for i := 0; i < n; i++ {
+		must(rs.AddKey(ar.key(i), uint64(residuals[i])))
+	}
+	must(rs.Build(ctx))
+	rs.Close()
+	ef := eliasfano32.NewEliasFano(uint64(n), maxOffset)
+	for i := 0; i < n; i++ {
+		ef.AddOffset(offs[i])
+	}
+	ef.Build()
+	must(os.WriteFile(efPath, ef.AppendBytes(nil), 0o644))
+	modelSz := writeModel(modelPath, segs)
+
+	// A/B: plain enums=true (full rank stored permuted + internal offset EF), no model
+	enumsPath := filepath.Join(*out, base+".enums.kvi")
+	var salt2 uint32 = 0
+	rsE, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
+		KeyCount: n, Enums: true, BucketSize: recsplit.DefaultBucketSize,
+		LeafSize: recsplit.DefaultLeafSize, TmpDir: *out, IndexFile: enumsPath,
+		Salt: &salt2, NoFsync: true,
+	}, logger)
+	must(err)
+	for i := 0; i < n; i++ {
+		must(rsE.AddKey(ar.key(i), offs[i]))
+	}
+	must(rsE.Build(ctx))
+	rsE.Close()
+	enumsSz := fileSize(enumsPath)
+
+	residSz, efSz := fileSize(residPath), fileSize(efPath)
+	newTotal := residSz + efSz + modelSz
+	baseKvi := (*kvPath)[:len(*kvPath)-3] + ".kvi"
+	baseSz := fileSize(baseKvi)
+	fmt.Printf("index sizes: new=%.0f MB (resid %.0f + ef %.0f + model %.0f) | enums=true=%.0f MB | baseline .kvi=%.0f MB\n",
+		mb(newTotal), mb(residSz), mb(efSz), mb(modelSz), mb(enumsSz), mb(baseSz))
+	fmt.Printf("  new is %.2fx smaller than baseline, %.2fx smaller than enums=true (model saves %.0f MB vs enums)\n",
+		float64(baseSz)/float64(newTotal), float64(enumsSz)/float64(newTotal), mb(enumsSz-newTotal))
+
+	// free build-time arena residuals (keep arena keys + offs for queries)
+	residuals = nil
+
+	rng := rand.New(rand.NewSource(1))
+	idxs := make([]int, *nkeys)
+	for i := range idxs {
+		idxs[i] = rng.Intn(n)
+	}
+	evict := func(files ...string) { _ = exec.Command("vmtouch", append([]string{"-e"}, files...)...).Run() }
+	load := func(files ...string) { _ = exec.Command("vmtouch", append([]string{"-t"}, files...)...).Run() }
+
+	runNew := func() float64 {
+		mdl := readModel(modelPath) // pinned-resident, like .bt pivots
+		idx, err := recsplit.OpenIndex(residPath)
+		must(err)
+		rd := recsplit.NewIndexReader(idx)
+		efr, efHandle := openEF(efPath)
+		dv, err := seg.NewDecompressor(*kvPath)
+		must(err)
+		vg := dv.MakeGetter()
+		vbuf := make([]byte, 0, 4096)
+		var sink int
+		t0 := time.Now()
+		for _, i := range idxs {
+			local, _ := rd.Lookup(ar.key(i))
+			rank := predict(mdl, ar.x(i), n) + minE + int(local)
+			vg.Reset(efr.Get(uint64(rank)))
+			if vg.HasNext() {
+				vbuf, _ = vg.Next(vbuf[:0])
+			}
+			sink += len(vbuf)
+		}
+		us := usOp(time.Since(t0), *nkeys)
+		idx.Close()
+		closeEF(efHandle)
+		dv.Close()
+		_ = sink
+		return us
+	}
+	runBase := func() float64 {
+		idx, err := recsplit.OpenIndex(baseKvi)
+		must(err)
+		rd := recsplit.NewIndexReader(idx)
+		dv, err := seg.NewDecompressor(*kvPath)
+		must(err)
+		vg := dv.MakeGetter()
+		vbuf := make([]byte, 0, 4096)
+		var sink int
+		t0 := time.Now()
+		for _, i := range idxs {
+			off, _ := rd.Lookup(ar.key(i))
+			vg.Reset(off)
+			if vg.HasNext() {
+				vbuf, _ = vg.Next(vbuf[:0])
+			}
+			sink += len(vbuf)
+		}
+		us := usOp(time.Since(t0), *nkeys)
+		idx.Close()
+		dv.Close()
+		_ = sink
+		return us
+	}
+
+	runEnums := func() float64 {
+		idx, err := recsplit.OpenIndex(enumsPath)
+		must(err)
+		rd := recsplit.NewIndexReader(idx)
+		dv, err := seg.NewDecompressor(*kvPath)
+		must(err)
+		vg := dv.MakeGetter()
+		vbuf := make([]byte, 0, 4096)
+		var sink int
+		t0 := time.Now()
+		for _, i := range idxs {
+			off, _ := rd.TwoLayerLookup(ar.key(i))
+			vg.Reset(off)
+			if vg.HasNext() {
+				vbuf, _ = vg.Next(vbuf[:0])
+			}
+			sink += len(vbuf)
+		}
+		us := usOp(time.Since(t0), *nkeys)
+		idx.Close()
+		dv.Close()
+		_ = sink
+		return us
+	}
+
+	fmt.Println("\n--- COLD (index + .kv evicted; model pinned, like .bt pivots) ---")
+	evict(residPath, efPath, *kvPath)
+	load(modelPath)
+	newCold := runNew()
+	fmt.Printf("new MMPHF+EF:  %.0f µs/op\n", newCold)
+	evict(enumsPath, *kvPath)
+	fmt.Printf("enums=true:    %.0f µs/op\n", runEnums())
+	if baseSz > 0 {
+		evict(baseKvi, *kvPath)
+		baseCold := runBase()
+		fmt.Printf("baseline .kvi: %.0f µs/op  (new is %.2fx %s)\n", baseCold, ratio(baseCold, newCold), faster(baseCold, newCold))
+	}
+
+	fmt.Println("\n--- WARM (index resident, .kv cold) ---")
+	load(residPath, efPath, modelPath)
+	evict(*kvPath)
+	fmt.Printf("new MMPHF+EF:  %.0f µs/op\n", runNew())
+	load(enumsPath)
+	evict(*kvPath)
+	fmt.Printf("enums=true:    %.0f µs/op\n", runEnums())
+	if baseSz > 0 {
+		load(baseKvi)
+		evict(*kvPath)
+		fmt.Printf("baseline .kvi: %.0f µs/op\n", runBase())
+	}
+}
+
+func openEF(path string) (*eliasfano32.EliasFano, []byte) {
+	f, err := os.Open(path)
+	must(err)
+	fi, _ := f.Stat()
+	m, _, err := mmap.Mmap(f, int(fi.Size()))
+	must(err)
+	f.Close()
+	ef, _ := eliasfano32.ReadEliasFano(m)
+	return ef, m
+}
+func closeEF(m []byte) { _ = mmap.Munmap(m, nil) }
+
+func mb(b int64) float64 { return float64(b) / 1e6 }
+func usOp(d time.Duration, n int) float64 {
+	return float64(d.Microseconds()) / float64(n)
+}
+func ratio(a, b float64) float64 {
+	if a > b {
+		return a / b
+	}
+	return b / a
+}
+func faster(base, new float64) string {
+	if new < base {
+		return "faster"
+	}
+	return "slower"
+}
+func fileSize(p string) int64 {
+	fi, err := os.Stat(p)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/scratch/kvi_mmphf/FINDINGS.md
+++ b/scratch/kvi_mmphf/FINDINGS.md
@@ -62,6 +62,42 @@ pushing commitment toward ~20 bits/key (**~2.5x**).
 - Halving the resident index (50.8 → ~26) directly addresses #21795's "kvi can't fit in memory"
   (4.46 GB → ~2.3 GB for the 0-8192 file), avoiding the 440–480µs cold path.
 
+## Cold/warm full-Get on real commitment files (15k random keys, vmtouch -e)
+
+| file | keys | baseline .kvi | new | size× | cold base→new | warm base→new |
+|---|---|---|---|---|---|---|
+| 9024-9056   | 18M  | 115 MB  | 66 MB  | 1.74× | 180→177 µs | 91→99 µs |
+| 187416-187418 | 34M | 213 MB | 121 MB | 1.76× | 208→205 µs | 83→93 µs |
+| 8704-8960   | 73M  | 464 MB  | 264 MB | 1.76× | 289→273 µs | 96→104 µs |
+| 0-102400 (v1) | 228M | 1454 MB | 791 MB | 1.84× | —/372 µs | — |
+
+A/B vs enums=true (14.5 GB file): baseline 213 MB → enums=true 187 MB (1.14×) → new 121 MB
+(1.76×). The learned model contributes 187→121 MB (1.55×) — most of the win. enums=true alone
+barely helps because the permuted full-rank array is nearly as big as the raw-offset array.
+
+Conclusion: MMPHF+EF is a memory-footprint win (1.74–1.84×, grows with scale) with comparable
+cold/warm latency. Cold full-Get is dominated by the shared .kv value-page fault, so a smaller
+index doesn't speed the per-lookup cold path — its value is residency (smaller → stays warm →
+~90 µs path). Harness reproduces #21795's 14.5 GB row (213 MB / 203 µs). Bench tool: scratch/kvi_coldbench/.
+
+## Recursive prefix-stripping model (solves the deep-prefix blowup)
+
+scratch/kvi_mmphf_rec/. Each node uses an EXACT uint64 coordinate = the 8 key bytes after
+that node's longest-common-prefix (LCP), so float precision lands on the first differing byte.
+Keys that still tie on those 8 bytes recurse one level deeper. Critically, a recursed group
+forces a SEGMENT BREAK in the parent so the parent never interpolates across the rank-gap the
+group leaves behind (that gap was the −1.29M residual outlier in the flat model).
+
+| file | keys | residual | recursion depth | bit-packed bits/key | vs baseline 50.8 |
+|---|---|---|---|---|---|
+| commitment 9024-9056 | 18M | 8 bits | 1 | 20.8 | 2.44× |
+| commitment 8704-8960 | 73M | 9 bits | 1 | ~21.4 | 2.37× |
+| accounts (uniform) | 2.6M | 7 bits | 0 (none) | 17.4 | — |
+
+100% correct. Uniform keys need no recursion (depth 0) and are unaffected. Recursive model
+improves commitment from the flat model's 1.94× to ~2.4× — meeting the projected ~2.5–3× range.
+(recsplit byte-rounds 9-bit residuals to 2 bytes; production bit-packing gives the ideal column.)
+
 ## Next steps for integration
 - Bit-packed residual store (not recsplit's byte-rounded bytesPerRec) — saves the rounding waste.
 - Recursive model for deep-prefix buckets.

--- a/scratch/kvi_mmphf_rec/main.go
+++ b/scratch/kvi_mmphf_rec/main.go
@@ -1,0 +1,335 @@
+// Recursive prefix-stripping learned model for the .kvi MMPHF.
+//
+// The flat model used one float coordinate over the whole 64-byte key, which
+// loses precision on deep-common-prefix groups (a contract's storage subtree).
+// Here each node uses an EXACT uint64 coordinate = the 8 key bytes after the
+// node's common prefix. Keys that tie on those 8 bytes (share prefix+8) recurse
+// one level deeper (prefix += 8), drilling to where keys diverge. The coordinate
+// is exact and monotonic at every level, so the residual collapses to ~eps.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/recsplit"
+	"github.com/erigontech/erigon/db/recsplit/eliasfano32"
+	"github.com/erigontech/erigon/db/seg"
+)
+
+type arena struct {
+	data []byte
+	off  []uint64
+}
+
+func (a *arena) n() int           { return len(a.off) - 1 }
+func (a *arena) key(i int) []byte { return a.data[a.off[i]:a.off[i+1]] }
+
+func coordAt(k []byte, p int) uint64 {
+	var c uint64
+	for b := 0; b < 8; b++ {
+		c <<= 8
+		if p+b < len(k) {
+			c |= uint64(k[p+b])
+		}
+	}
+	return c
+}
+
+type pseg struct {
+	c0    uint64
+	y0    float64
+	slope float64
+}
+
+type node struct {
+	p        int
+	segs     []pseg
+	children map[uint64]*node
+}
+
+// buildSegments over (coord, rank) points; coords monotonic non-decreasing.
+func buildSegments(cs []uint64, ranks []int, eps float64) []pseg {
+	var segs []pseg
+	m := len(cs)
+	i := 0
+	for i < m {
+		c0 := cs[i]
+		y0 := float64(ranks[i])
+		slopeLo, slopeHi := math.Inf(-1), math.Inf(1)
+		j := i + 1
+		for ; j < m; j++ {
+			dx := float64(cs[j] - c0)
+			yj := float64(ranks[j])
+			if dx == 0 {
+				if math.Abs(yj-y0) > eps {
+					break
+				}
+				continue
+			}
+			lo := (yj - eps - y0) / dx
+			hi := (yj + eps - y0) / dx
+			if lo > slopeLo {
+				slopeLo = lo
+			}
+			if hi < slopeHi {
+				slopeHi = hi
+			}
+			if slopeLo > slopeHi {
+				break
+			}
+		}
+		slope := 0.0
+		if !math.IsInf(slopeLo, 0) && !math.IsInf(slopeHi, 0) {
+			slope = (slopeLo + slopeHi) / 2
+		} else if !math.IsInf(slopeLo, 0) {
+			slope = slopeLo
+		} else if !math.IsInf(slopeHi, 0) {
+			slope = slopeHi
+		}
+		segs = append(segs, pseg{c0: c0, y0: y0, slope: slope})
+		i = j
+	}
+	return segs
+}
+
+var nNodes, nSegs, nChildren, maxDepth int
+
+func commonPrefixLen(a, b []byte) int {
+	m := len(a)
+	if len(b) < m {
+		m = len(b)
+	}
+	for i := 0; i < m; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return m
+}
+
+func buildNode(a *arena, lo, hi, depth int, eps float64) *node {
+	if depth > maxDepth {
+		maxDepth = depth
+	}
+	nNodes++
+	// coordinate offset = LCP of this range (sorted => LCP(first,last)); puts
+	// float precision on the first differing byte, not a constant high byte.
+	p := commonPrefixLen(a.key(lo), a.key(hi-1))
+	n := &node{p: p}
+	var cs []uint64
+	var ranks []int
+	flush := func() {
+		if len(cs) > 0 {
+			n.segs = append(n.segs, buildSegments(cs, ranks, eps)...)
+			cs, ranks = cs[:0], ranks[:0]
+		}
+	}
+	i := lo
+	for i < hi {
+		c := coordAt(a.key(i), p)
+		j := i + 1
+		for j < hi && coordAt(a.key(j), p) == c {
+			j++
+		}
+		if j-i > int(2*eps+1) {
+			// tie on these 8 bytes too big to absorb in a residual -> recurse deeper.
+			// Break the segment here so the parent never interpolates across the
+			// rank-gap the recursed group leaves behind.
+			flush()
+			if n.children == nil {
+				n.children = map[uint64]*node{}
+			}
+			n.children[c] = buildNode(a, i, j, depth+1, eps)
+			nChildren++
+		} else {
+			for r := i; r < j; r++ {
+				cs = append(cs, c)
+				ranks = append(ranks, r)
+			}
+		}
+		i = j
+	}
+	flush()
+	nSegs += len(n.segs)
+	return n
+}
+
+func predict(n *node, key []byte, total int) int {
+	for {
+		c := coordAt(key, n.p)
+		if n.children != nil {
+			if ch, ok := n.children[c]; ok {
+				n = ch
+				continue
+			}
+		}
+		lo, hi, idx := 0, len(n.segs)-1, 0
+		for lo <= hi {
+			mid := (lo + hi) / 2
+			if n.segs[mid].c0 <= c {
+				idx = mid
+				lo = mid + 1
+			} else {
+				hi = mid - 1
+			}
+		}
+		s := n.segs[idx]
+		p := int(math.Round(s.y0 + s.slope*float64(c-s.c0)))
+		if p < 0 {
+			p = 0
+		}
+		if p >= total {
+			p = total - 1
+		}
+		return p
+	}
+}
+
+func main() {
+	kvPath := flag.String("kv", "", ".kv data file")
+	eps := flag.Int("eps", 31, "model error bound")
+	flag.Parse()
+	if *kvPath == "" {
+		fmt.Println("need -kv")
+		os.Exit(1)
+	}
+	logger := log.New()
+	ctx := context.Background()
+	fmt.Printf("=== %s  eps=%d (recursive) ===\n", filepath.Base(*kvPath), *eps)
+
+	d, err := seg.NewDecompressor(*kvPath)
+	must(err)
+	defer d.Close()
+	g := d.MakeGetter()
+	g.Reset(0)
+	cnt := d.Count() / 2
+	ar := &arena{data: make([]byte, 0, 1<<30), off: make([]uint64, 0, cnt+1)}
+	offs := make([]uint64, 0, cnt)
+	buf := make([]byte, 0, 256)
+	for g.HasNext() {
+		key, valPos := g.Next(buf[:0])
+		ar.off = append(ar.off, uint64(len(ar.data)))
+		ar.data = append(ar.data, key...)
+		offs = append(offs, valPos)
+		if g.HasNext() {
+			g.Skip()
+		}
+	}
+	ar.off = append(ar.off, uint64(len(ar.data)))
+	n := ar.n()
+	maxOffset := offs[n-1]
+	fmt.Printf("keys=%d  .kv=%.2f GB\n", n, float64(fileSize(*kvPath))/1e9)
+
+	t0 := time.Now()
+	root := buildNode(ar, 0, n, 0, float64(*eps))
+	// model bytes: each seg = c0(8)+y0(8)+slope(8)=24; each child edge = coord(8)+ptr(8)=16
+	modelBytes := nSegs*24 + nChildren*16
+	fmt.Printf("model: nodes=%d segs=%d children=%d maxDepth=%d (%.3f bits/key) build=%s\n",
+		nNodes, nSegs, nChildren, maxDepth, float64(modelBytes*8)/float64(n), time.Since(t0).Round(time.Millisecond))
+
+	minE, maxE := math.MaxInt, math.MinInt
+	residuals := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		e := i - predict(root, ar.key(i), n)
+		residuals[i] = uint64(e)
+		if e < minE {
+			minE = e
+		}
+		if e > maxE {
+			maxE = e
+		}
+	}
+	for i := 0; i < n; i++ {
+		residuals[i] = uint64(int(int64(residuals[i])) - minE)
+	}
+	residBits := int(math.Ceil(math.Log2(float64(maxE - minE + 1))))
+	fmt.Printf("residual: range=[%d,%d] -> %d bits/key\n", minE, maxE, residBits)
+
+	// build recsplit(residual) + EF(offsets) for real sizes
+	tmp, _ := os.MkdirTemp("", "mmphfrec")
+	defer os.RemoveAll(tmp)
+	idxPath := filepath.Join(tmp, "resid.kvi")
+	var salt uint32 = 0
+	rs, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
+		KeyCount: n, Enums: false, BucketSize: recsplit.DefaultBucketSize,
+		LeafSize: recsplit.DefaultLeafSize, TmpDir: tmp, IndexFile: idxPath,
+		Salt: &salt, NoFsync: true,
+	}, logger)
+	must(err)
+	for i := 0; i < n; i++ {
+		must(rs.AddKey(ar.key(i), residuals[i]))
+	}
+	must(rs.Build(ctx))
+	rs.Close()
+	residSz := fileSize(idxPath)
+	ef := eliasfano32.NewEliasFano(uint64(n), maxOffset)
+	for i := 0; i < n; i++ {
+		ef.AddOffset(offs[i])
+	}
+	ef.Build()
+	efBytes := len(ef.AppendBytes(nil))
+
+	// verify
+	idx, err := recsplit.OpenIndex(idxPath)
+	must(err)
+	defer idx.Close()
+	rd := recsplit.NewIndexReader(idx)
+	efr, _ := eliasfano32.ReadEliasFano(ef.AppendBytes(nil))
+	bad := 0
+	for i := 0; i < n; i++ {
+		local, _ := rd.Lookup(ar.key(i))
+		rank := predict(root, ar.key(i), n) + minE + int(local)
+		if rank < 0 || rank >= n || efr.Get(uint64(rank)) != offs[i] {
+			bad++
+		}
+	}
+	fmt.Printf("verify: %d/%d correct\n", n-bad, n)
+
+	newTotal := residSz + int64(efBytes) + int64(modelBytes)
+	mphfOverhead := float64(residSz*8)/float64(n) - 8*math.Ceil(float64(maxE-minE+1)/256)
+	if mphfOverhead < 0 {
+		mphfOverhead = 0
+	}
+	efBitsPK := float64(efBytes*8) / float64(n)
+	idealBits := efBitsPK + float64(modelBytes*8)/float64(n) + mphfOverhead + float64(residBits)
+	baseKvi := (*kvPath)[:len(*kvPath)-3] + ".kvi"
+	baseSz := fileSize(baseKvi)
+	fmt.Printf("recsplit(resid)=%.0fMB EF=%.0fMB model=%.1fMB\n", mb(residSz), float64(efBytes)/1e6, float64(modelBytes)/1e6)
+	if baseSz > 0 {
+		fmt.Printf("baseline .kvi: %.0f MB (%.1f bits/key)\n", mb(baseSz), float64(baseSz*8)/float64(n))
+	}
+	fmt.Printf("new (recsplit-bound): %.0f MB (%.1f bits/key)\n", mb(newTotal), float64(newTotal*8)/float64(n))
+	fmt.Printf("new (bit-packed ideal): %.1f bits/key [EF=%.1f + model=%.3f + mphf=%.1f + resid=%d]\n",
+		idealBits, efBitsPK, float64(modelBytes*8)/float64(n), mphfOverhead, residBits)
+	if baseSz > 0 {
+		fmt.Printf("reduction: recsplit-bound %.2fx | ideal %.2fx\n",
+			float64(baseSz)/float64(newTotal), float64(baseSz*8)/float64(n)/idealBits)
+	}
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func mb(b int64) float64 { return float64(b) / 1e6 }
+func fileSize(p string) int64 {
+	fi, err := os.Stat(p)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Stacked on #2. Adds the recursive prefix-stripping model that fixes the deep-common-prefix blowup, plus an on-disk cold/warm full-Get benchmark.

Recursive model (scratch/kvi_mmphf_rec): each node uses an exact uint64 coordinate = the 8 key bytes after that node's longest-common-prefix, so precision lands on the first differing byte; ties recurse deeper. A recursed group forces a segment break in the parent so it never interpolates across the rank-gap the group leaves behind.

Exact index sizes (recursive model), 100% correct. recsplit byte-rounds the residual to whole bytes; production bit-packing gives the "ideal" column:

| file | keys | baseline .kvi | new (recsplit-bound) | new (bit-packed) | residual | reduction (ideal) |
|---|---|---|---|---|---|---|
| commitment 9024-9056 | 18M | 114.8 MB | 46.6 MB | 46.6 MB | 8 bits | 2.46x |
| commitment 8704-8960 | 73M | 464.5 MB | 260 MB | ~22 b/k | 9 bits | 2.37x |
| commitment 8192-8704 | 141M | 883 MB | 491 MB | 21.2 b/k | 9 bits | **2.39x** |
| accounts (uniform) | 2.6M | — | ~6 MB | 17.4 b/k | 7 bits | — |

(8-bit residual = exactly 1 byte, no waste, so recsplit-bound == ideal. 9-bit residual byte-rounds to 2 bytes, inflating the recsplit-bound column; bit-packing recovers the ideal ~2.4x.) Improves commitment from the flat model's 1.94x to ~2.4x. Uniform keys need no recursion (depth 0).

### History .vi also applies

`.vi` (history accessor, also `Enums:false` -> same permuted-offset shuffle) works too, with a **key-major coordinate** (`key||txNum`) so offsets are monotone in the model's order (historyKey is txNum-major and would NOT be monotone). No `.v` reorder needed.

| file | entries | baseline .vi | new (recsplit-bound) | new (bit-packed) | residual | reduction (ideal) |
|---|---|---|---|---|---|---|
| accounts .vi 9024-9056 | 37M | 157 MB | 116 MB | 18.2 b/k | 11 bits | 1.86x |
| accounts .vi 8960-9024 | 70M | 294 MB | 214 MB | 17.8 b/k | 11 bits | **1.90x** |

Cold-bench tool (scratch/kvi_coldbench): whole index on disk (residual recsplit + EF + model), mmap Get reader, vmtouch -e cold/warm full-Get vs baseline .kvi. Confirms the win is memory footprint (smaller index), latency comparable; reproduces the published 14.5GB row (213MB / ~205us).

Note: a tuned `.bt`+interp (erigontech PR 21813) matches lemonsplit's storage via its M knob and beats it on cold latency, so `.bt` is the stronger direction for the #21795 memory-pressure goal; lemonsplit's edge is warm hash-lookup speed + keeping the `.kvi`/`.vi` format. Writeup: scratch/kvi_mmphf/FINDINGS.md. Prototype only.
