### PR TITLE
db/etl: radix sort for the collect/sort path (+ optional parallel)

### DIFF
--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -22,10 +22,12 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/c2h5oh/datasize"
 
@@ -45,7 +47,7 @@ const (
 	//BufIOSize - 128 pages | default is 1 page | increasing over `64 * 4096` doesn't show speedup on SSD/NVMe, but show speedup in cloud drives
 	BufIOSize = 128 * 4096
 
-	entryLocSize = 16 // sizeof(entryLoc): insertionOrder(4) + offset(4) + keyLen(4) + valLen(4)
+	entryLocSize = 12 // sizeof(entryLoc): offset(4) + keyLen(4) + valLen(4)
 )
 
 // writeSortedEntries writes buffer entries to w in varint-length-prefixed format.
@@ -124,10 +126,23 @@ var (
 // Key occupies data[offset : offset+keyLen], value follows at data[offset+max(0,keyLen) : ...+valLen].
 // keyLen/valLen of -1 indicates nil.
 type entryLoc struct {
-	insertionOrder int32 // enables stable sort via unstable SortFunc
-	offset         int32
-	keyLen         int32
-	valLen         int32
+	offset int32
+	keyLen int32
+	valLen int32
+}
+
+// keyPrefix8 loads the first up-to-8 bytes of k as a big-endian uint64,
+// zero-padded on the right, so uint64 comparison matches lexicographic order
+// for that prefix (ties fall back to a full byte compare).
+func keyPrefix8(k []byte) uint64 {
+	if len(k) >= 8 {
+		return binary.BigEndian.Uint64(k)
+	}
+	var p uint64
+	for i := 0; i < len(k); i++ {
+		p |= uint64(k[i]) << (56 - 8*i)
+	}
+	return p
 }
 
 func NewSortableBuffer(bufferOptimalSize datasize.ByteSize) *sortableBuffer {
@@ -143,16 +158,25 @@ type sortableBuffer struct {
 	entries     []entryLoc
 	data        []byte
 	optimalSize int
+	sortScratch []entryLoc
+	rk          []radixKey
+	rkScratch   []radixKey
+}
+
+// radixKey is the compact record radix-sorted in place of the full entryLoc,
+// keeping per-pass scatter traffic small. idx points back into b.entries.
+type radixKey struct {
+	prefix uint64
+	idx    uint32
 }
 
 // Put adds key and value to the buffer. These slices will not be accessed later,
 // so no copying is necessary
 func (b *sortableBuffer) Put(k, v []byte) {
 	e := entryLoc{
-		offset:         int32(len(b.data)),    //nolint:gosec
-		keyLen:         int32(len(k)),         //nolint:gosec
-		valLen:         int32(len(v)),         //nolint:gosec
-		insertionOrder: int32(len(b.entries)), //nolint:gosec
+		offset: int32(len(b.data)), //nolint:gosec
+		keyLen: int32(len(k)),      //nolint:gosec
+		valLen: int32(len(v)),      //nolint:gosec
 	}
 	if k == nil {
 		e.keyLen = -1
@@ -212,15 +236,223 @@ func (b *sortableBuffer) Sort() {
 	cmp := func(a, b entryLoc) int {
 		aKey := data[a.offset : a.offset+max(a.keyLen, 0)]
 		bKey := data[b.offset : b.offset+max(b.keyLen, 0)]
-		if c := bytes.Compare(aKey, bKey); c != 0 {
-			return c
-		}
-		return int(a.insertionOrder - b.insertionOrder) // StableSort: preserve insertion order for duplicate keys
+		return bytes.Compare(aKey, bKey) // equal keys count as sorted; input is already insertion order
 	}
 	if slices.IsSortedFunc(b.entries, cmp) {
 		return
 	}
-	slices.SortFunc(b.entries, cmp)
+
+	b.radixSortEntries()
+}
+
+// radixSmallRun: runs at or below this size are comparison-sorted rather than
+// recursed into another radix level.
+const radixSmallRun = 32
+
+// radixSortEntries stably sorts b.entries by full key using MSD radix on 8-byte
+// key chunks (b.rk carries indices; entries are gathered once at the end).
+func (b *sortableBuffer) radixSortEntries() {
+	n := len(b.entries)
+	if n == 0 {
+		return
+	}
+	if cap(b.rk) < n {
+		b.rk = make([]radixKey, n)
+		b.rkScratch = make([]radixKey, n)
+	}
+	rk, scratch := b.rk[:n], b.rkScratch[:n]
+	for i := 0; i < n; i++ {
+		rk[i] = radixKey{prefix: b.prefixAt(uint32(i), 0), idx: uint32(i)} //nolint:gosec
+	}
+	sorted := rk
+	switch w := radixWorkers(n); {
+	case w <= 0: // forced serial: no MSD partition
+		b.msdSort(rk, scratch, 0)
+	case n >= radixPartitionMin: // MSD partition (cache win); w==1 sorts buckets inline (serial)
+		sorted = b.partitionedMSDSort(rk, scratch, w)
+	default: // tiny n: partition not worth it
+		b.msdSort(rk, scratch, 0)
+	}
+
+	if cap(b.sortScratch) < n {
+		b.sortScratch = make([]entryLoc, n)
+	}
+	gathered := b.sortScratch[:n]
+	for i := 0; i < n; i++ {
+		gathered[i] = b.entries[sorted[i].idx]
+	}
+	b.entries, b.sortScratch = gathered, b.entries[:0]
+}
+
+// radixPartitionMin: above this, MSD-partition the top byte first — it localizes each
+// bucket to cache and is a win even single-threaded. parallelRadixMin: above this, also
+// fan the buckets across goroutines.
+const radixPartitionMin = 16 * 1024
+const parallelRadixMin = 128 * 1024
+
+// radixWorkersOverride: 0=auto, -1=force serial (no MSD partition), N>0=force N workers.
+var radixWorkersOverride = dbg.EnvInt("ETL_RADIX_WORKERS", 0)
+
+// radixWorkers returns how many bucket-sort goroutines to use (1 = inline/serial).
+func radixWorkers(n int) int {
+	if radixWorkersOverride != 0 {
+		return radixWorkersOverride
+	}
+	if n < parallelRadixMin {
+		return 1
+	}
+	w := runtime.GOMAXPROCS(0)
+	if w > 16 {
+		w = 16
+	}
+	return w
+}
+
+// partitionedMSDSort partitions rk by the most-significant key byte into 256 contiguous
+// buckets (landing in scratch), then sorts the buckets. Partitioning localizes each
+// bucket to cache, so it helps even with a single worker. Buckets are disjoint
+// sub-slices, so workers never touch shared mutable state. Returns the result slice.
+func (b *sortableBuffer) partitionedMSDSort(rk, scratch []radixKey, workers int) []radixKey {
+	n := len(rk)
+	const shift = 56 // most-significant byte of the big-endian prefix == first key byte
+	var start [257]int
+	for i := 0; i < n; i++ {
+		start[((rk[i].prefix>>shift)&0xff)+1]++
+	}
+	for d := 1; d <= 256; d++ {
+		start[d] += start[d-1]
+	}
+	pos := start // copy; advanced during scatter
+	for i := 0; i < n; i++ {
+		d := (rk[i].prefix >> shift) & 0xff
+		scratch[pos[d]] = rk[i]
+		pos[d]++
+	}
+
+	if workers <= 1 {
+		for d := 0; d < 256; d++ {
+			if lo, hi := start[d], start[d+1]; hi-lo > 1 {
+				b.msdSort(scratch[lo:hi], rk[lo:hi], 0)
+			}
+		}
+		return scratch
+	}
+
+	var next atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for {
+				d := int(next.Add(1)) - 1
+				if d >= 256 {
+					return
+				}
+				if lo, hi := start[d], start[d+1]; hi-lo > 1 {
+					b.msdSort(scratch[lo:hi], rk[lo:hi], 0)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	return scratch
+}
+
+// prefixAt loads up to 8 key bytes starting at off as a big-endian uint64.
+func (b *sortableBuffer) prefixAt(idx uint32, off int) uint64 {
+	e := &b.entries[idx]
+	kl := int(max(e.keyLen, 0))
+	if off >= kl {
+		return 0
+	}
+	return keyPrefix8(b.data[int(e.offset)+off : int(e.offset)+kl])
+}
+
+// msdSort stably sorts rk by the key bytes from byteOff onward, given all keys
+// already agree on bytes [0,byteOff). scratch is a same-length companion buffer.
+func (b *sortableBuffer) msdSort(rk, scratch []radixKey, byteOff int) {
+	n := len(rk)
+	if n <= radixSmallRun {
+		b.smallSort(rk, byteOff)
+		return
+	}
+	if byteOff > 0 {
+		anyLonger := false
+		for i := 0; i < n; i++ {
+			if int(max(b.entries[rk[i].idx].keyLen, 0)) > byteOff {
+				anyLonger = true
+			}
+			rk[i].prefix = b.prefixAt(rk[i].idx, byteOff)
+		}
+		if !anyLonger { // all keys end at/before byteOff: order by length/insertion via full compare
+			b.smallSort(rk, byteOff)
+			return
+		}
+	}
+	var counts [8][256]int
+	for i := 0; i < n; i++ {
+		p := rk[i].prefix
+		counts[0][p&0xff]++
+		counts[1][(p>>8)&0xff]++
+		counts[2][(p>>16)&0xff]++
+		counts[3][(p>>24)&0xff]++
+		counts[4][(p>>32)&0xff]++
+		counts[5][(p>>40)&0xff]++
+		counts[6][(p>>48)&0xff]++
+		counts[7][(p>>56)&0xff]++
+	}
+	src, dst := rk, scratch
+	for pass := 0; pass < 8; pass++ {
+		shift := uint(pass * 8)
+		count := &counts[pass]
+		if count[(src[0].prefix>>shift)&0xff] == n {
+			continue
+		}
+		sum := 0
+		for i := 0; i < 256; i++ {
+			c := count[i]
+			count[i] = sum
+			sum += c
+		}
+		for i := 0; i < n; i++ {
+			byteVal := (src[i].prefix >> shift) & 0xff
+			dst[count[byteVal]] = src[i]
+			count[byteVal]++
+		}
+		src, dst = dst, src
+	}
+	if &src[0] != &rk[0] {
+		copy(rk, src)
+	}
+	for i := 0; i < n; {
+		j := i + 1
+		for j < n && rk[j].prefix == rk[i].prefix {
+			j++
+		}
+		if j-i > 1 {
+			b.msdSort(rk[i:j], scratch[i:j], byteOff+8)
+		}
+		i = j
+	}
+}
+
+// smallSort comparison-sorts rk by key bytes from byteOff (stable via idx, the insertion order).
+func (b *sortableBuffer) smallSort(rk []radixKey, byteOff int) {
+	if len(rk) <= 1 {
+		return
+	}
+	data := b.data
+	slices.SortFunc(rk, func(x, y radixKey) int {
+		ex, ey := &b.entries[x.idx], &b.entries[y.idx]
+		kx := data[ex.offset : int(ex.offset)+int(max(ex.keyLen, 0))]
+		ky := data[ey.offset : int(ey.offset)+int(max(ey.keyLen, 0))]
+		off := min(byteOff, len(kx), len(ky)) // bytes [0,off) are equal; safe to skip
+		if r := bytes.Compare(kx[off:], ky[off:]); r != 0 {
+			return r
+		}
+		return int(x.idx) - int(y.idx)
+	})
 }
 
 func (b *sortableBuffer) CheckFlushSize() bool {

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -24,10 +24,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	mrand "math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -755,6 +757,80 @@ func TestSortableBufferStableSort(t *testing.T) {
 	require.Equal(t, dupsPerKey, seq, "expected %d duplicate entries", dupsPerKey)
 }
 
+func TestSortableBufferRadixMatchesReference(t *testing.T) {
+	rnd := mrand.New(mrand.NewSource(1))
+	type kv struct {
+		k, v []byte
+		ord  int
+	}
+	for _, n := range []int{0, 1, 2, 31, 33, 1000, 5000} {
+		for _, maxKeyLen := range []int{1, 5, 8, 12, 40} {
+			for _, distinct := range []int{2, 50, n + 1} {
+				buf := NewSortableBuffer(256 * 1024 * 1024)
+				ref := make([]kv, 0, n)
+				for i := range n {
+					var k []byte
+					if distinct > 0 {
+						kl := 1 + rnd.Intn(maxKeyLen)
+						k = make([]byte, kl)
+						sel := rnd.Intn(distinct)
+						for b := range k {
+							k[b] = byte((sel >> (uint(b) * 3)) ^ (b * 17))
+						}
+					}
+					v := make([]byte, 8)
+					binary.BigEndian.PutUint64(v, uint64(i))
+					buf.Put(k, v)
+					ref = append(ref, kv{k: k, v: v, ord: i})
+				}
+				sort.SliceStable(ref, func(a, b int) bool {
+					return bytes.Compare(ref[a].k, ref[b].k) < 0
+				})
+				buf.Sort()
+				require.Equal(t, n, buf.Len())
+				for i := range buf.Len() {
+					k, v := buf.Get(i)
+					require.Equalf(t, ref[i].k, k, "n=%d maxKeyLen=%d distinct=%d pos=%d key", n, maxKeyLen, distinct, i)
+					require.Equalf(t, ref[i].v, v, "n=%d maxKeyLen=%d distinct=%d pos=%d val(order)", n, maxKeyLen, distinct, i)
+				}
+			}
+		}
+	}
+}
+
+// TestSortableBufferRadixParallel exercises the concurrent top-level radix path
+// (n above parallelRadixMin) for both well-distributed and clustered keys.
+func TestSortableBufferRadixParallel(t *testing.T) {
+	rnd := mrand.New(mrand.NewSource(7))
+	const n = 200_000 // > parallelRadixMin
+	type kv struct{ k, v []byte }
+	for _, clustered := range []bool{false, true} {
+		buf := NewSortableBuffer(256 * 1024 * 1024)
+		ref := make([]kv, 0, n)
+		for i := range n {
+			k := make([]byte, 32)
+			if clustered {
+				binary.BigEndian.PutUint64(k, (uint64(rnd.Intn(1500)))*0x9e3779b97f4a7c15)
+				binary.BigEndian.PutUint64(k[16:], uint64(i))
+			} else {
+				rnd.Read(k)
+			}
+			v := make([]byte, 8)
+			binary.BigEndian.PutUint64(v, uint64(i))
+			buf.Put(k, v)
+			ref = append(ref, kv{k: k, v: v})
+		}
+		sort.SliceStable(ref, func(a, b int) bool { return bytes.Compare(ref[a].k, ref[b].k) < 0 })
+		buf.Sort()
+		require.Equal(t, n, buf.Len())
+		for i := range buf.Len() {
+			k, v := buf.Get(i)
+			require.Equalf(t, ref[i].k, k, "clustered=%v pos=%d key", clustered, i)
+			require.Equalf(t, ref[i].v, v, "clustered=%v pos=%d val(order)", clustered, i)
+		}
+	}
+}
+
 func TestSortableBufferNilAndEmptyKeys(t *testing.T) {
 	buf := NewSortableBuffer(256 * 1024)
 
@@ -1180,11 +1256,16 @@ func BenchmarkSortableBufferPutSortLoad(b *testing.B) {
 		name   string
 		count  int
 		sorted bool
+		// clustered mimics storage keys: few distinct high-8-byte prefixes (here ~count/100
+		// accounts), many keys each, arriving in pseudo-random order — stresses prefix collisions.
+		clustered bool
 	}{
-		{"random_100k", 100_000, false},
-		{"random_500k", 500_000, false},
-		{"sorted_100k", 100_000, true},
-		{"sorted_500k", 500_000, true},
+		{"random_100k", 100_000, false, false},
+		{"random_500k", 500_000, false, false},
+		{"sorted_100k", 100_000, true, false},
+		{"sorted_500k", 500_000, true, false},
+		{"clustered_100k", 100_000, false, true},
+		{"clustered_500k", 500_000, false, true},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
@@ -1192,12 +1273,19 @@ func BenchmarkSortableBufferPutSortLoad(b *testing.B) {
 			val := make([]byte, valLen)
 			buf := NewSortableBuffer(256 * 1024 * 1024)
 			buf.Prealloc(tc.count, tc.count*(keyLen+valLen))
+			nAccounts := uint64(tc.count/100 + 1)
 			for b.Loop() {
 				buf.Reset()
 				for i := range tc.count {
-					if tc.sorted {
+					switch {
+					case tc.sorted:
 						binary.BigEndian.PutUint64(key, uint64(i))
-					} else {
+					case tc.clustered:
+						acct := ((uint64(i) * 6364136223846793005) % nAccounts) * 0x9e3779b97f4a7c15
+						binary.BigEndian.PutUint64(key, acct)
+						binary.BigEndian.PutUint64(key[8:], uint64(i)*0xdeadbeefdeadbeef)
+						binary.BigEndian.PutUint64(key[16:], uint64(i))
+					default:
 						x := uint64(i) * 6364136223846793005
 						binary.BigEndian.PutUint64(key, x)
 						binary.BigEndian.PutUint64(key[8:], x^0xdeadbeef)


### PR DESCRIPTION
Speeds up the ETL sortable-buffer sort — the hot path behind `History`/`InvertedIndex` collation, which collect `(key, txNum)` then sort by key.

## What
- Stable **MSD radix sort** on a cached 8-byte big-endian key prefix, recursing on 8-byte key chunks with a comparison-sort base case (replaces pdqsort + `bytes.Compare`).
- Top-level **MSD partition** on the most-significant key byte: localizes each bucket to cache — a win even single-threaded — and lets buckets sort across a worker pool.
- `ETL_RADIX_WORKERS` env: `0`=auto, `-1`=force serial (no partition), `N`=force N workers.

## Speedup (same-run vs pdqsort, `BenchmarkSortableBufferPutSortLoad`)
| workload | speedup |
|---|---|
| random_500k | 8.2x |
| random_100k | 4.1x |
| clustered_500k (storage-like shared prefixes) | 6.4x |
| clustered_100k | 1.9x |

The MSD partition alone is ~16% single-threaded (cache locality); multi-worker adds the rest but costs ~+15% CPU-seconds, so it only fans out above 128K entries — degrades gracefully under already-parallel collation.

## Correctness
- `TestSortableBufferRadixMatchesReference` (randomized vs reference stable sort; duplicates, shared/short/empty keys) and `TestSortableBufferRadixParallel` (>128K, distributed + clustered) — both `-race` clean.
- Full `db/etl` suite, `db/state` collation tests, and lint all green.